### PR TITLE
Update getSSIDs returned type

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -4,7 +4,7 @@ export interface CapacitorWifiConnectPlugin {
   requestPermission(): Promise<{ value: PermissionState }>;
   disconnect(): Promise<{ value: boolean }>;
 
-  getSSIDs(): Promise<string[]>
+  getSSIDs(): Promise<{ value: string[] }>
   getSSID(): Promise<{ value: string }>;
 
   connect(options: {


### PR DESCRIPTION
After some testing on Android I figured that getSSIDs returns { value: string[] } and not a string.