### PR TITLE
Refactor: update permissions for Android 13+

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <!-- For Android 13+: Use NEARBY_WIFI_DEVICES for WiFi operations without deriving location -->
+  <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"
+    android:usesPermissionFlags="neverForLocation" />
+
+  <!-- For Android 10-12: Location permission is required for WiFi APIs -->
+  <!-- For Android < 10: Required for WiFi scanning operations -->
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+    android:maxSdkVersion="32" />
+
+  <!-- Required for WiFi operations -->
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
   <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,8 +3,11 @@
   <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"
     android:usesPermissionFlags="neverForLocation" />
 
-  <!-- For Android 10-12: Location permission is required for WiFi APIs -->
+  <!-- For Android 10-12: Location permissions are required for WiFi APIs -->
   <!-- For Android < 10: Required for WiFi scanning operations -->
+  <!-- Note: Both COARSE and FINE are required together on Android 12+ -->
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"
+    android:maxSdkVersion="32" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
     android:maxSdkVersion="32" />
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,15 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-  <!-- For Android 13+: Use NEARBY_WIFI_DEVICES for WiFi operations without deriving location -->
+  <!-- For Android 13+: Use NEARBY_WIFI_DEVICES for WiFi connection operations without deriving location -->
   <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"
     android:usesPermissionFlags="neverForLocation" />
 
-  <!-- For Android 10-12: Location permissions are required for WiFi APIs -->
-  <!-- For Android < 10: Required for WiFi scanning operations -->
-  <!-- Note: Both COARSE and FINE are required together on Android 12+ -->
-  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"
-    android:maxSdkVersion="32" />
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
-    android:maxSdkVersion="32" />
+  <!-- Location permissions are required for:
+       - WiFi scanning operations (startScan, getScanResults) on ALL Android versions including 13+
+       - WiFi connection operations on Android < 13
+       Note: Both COARSE and FINE are required together on Android 12+ -->
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
   <!-- Required for WiFi operations -->
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/android/src/main/kotlin/com/falconeta/capacitor_wifi_connect/CapacitorWifiConnect.kt
+++ b/android/src/main/kotlin/com/falconeta/capacitor_wifi_connect/CapacitorWifiConnect.kt
@@ -83,12 +83,15 @@ class CapacitorWifiConnect(context: Context) : LifecycleObserver {
     call: PluginCall
   ) {
 
-    val networkEnabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
-    if (!networkEnabled) {
-      val ret = JSObject()
-      ret.put("value", -6)
-      call.resolve(ret)
-      return
+    // For Android Q+ using WifiNetworkSpecifier, location services don't need to be enabled
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      val networkEnabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+      if (!networkEnabled) {
+        val ret = JSObject()
+        ret.put("value", -6)
+        call.resolve(ret)
+        return
+      }
     }
 
     if(!wifiManager.isWifiEnabled) {
@@ -122,12 +125,16 @@ class CapacitorWifiConnect(context: Context) : LifecycleObserver {
     call: PluginCall
   ) {
 
-    val networkEnabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
-    if (!networkEnabled) {
-      val ret = JSObject()
-      ret.put("value", -6)
-      call.resolve(ret)
-      return
+    // For Android Q+ using WifiNetworkSpecifier, location services don't need to be enabled
+    // For Android < Q, location services are checked because WiFi scanning is used
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      val networkEnabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+      if (!networkEnabled) {
+        val ret = JSObject()
+        ret.put("value", -6)
+        call.resolve(ret)
+        return
+      }
     }
 
     if(!wifiManager.isWifiEnabled) {
@@ -164,12 +171,15 @@ class CapacitorWifiConnect(context: Context) : LifecycleObserver {
     call: PluginCall
   ) {
 
-    val networkEnabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
-    if (!networkEnabled) {
-      val ret = JSObject()
-      ret.put("value", -6)
-      call.resolve(ret)
-      return
+    // For Android Q+ using WifiNetworkSpecifier, location services don't need to be enabled
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      val networkEnabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+      if (!networkEnabled) {
+        val ret = JSObject()
+        ret.put("value", -6)
+        call.resolve(ret)
+        return
+      }
     }
 
     if(!wifiManager.isWifiEnabled) {
@@ -213,12 +223,16 @@ class CapacitorWifiConnect(context: Context) : LifecycleObserver {
     call: PluginCall
   ) {
 
-    val networkEnabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
-    if (!networkEnabled) {
-      val ret = JSObject()
-      ret.put("value", -6)
-      call.resolve(ret)
-      return
+    // For Android Q+ using WifiNetworkSpecifier, location services don't need to be enabled
+    // For Android < Q, location services are checked because WiFi scanning is used
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      val networkEnabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+      if (!networkEnabled) {
+        val ret = JSObject()
+        ret.put("value", -6)
+        call.resolve(ret)
+        return
+      }
     }
 
     if(!wifiManager.isWifiEnabled) {


### PR DESCRIPTION
In my app, I am primarily using the `securePrefixConnect(...)` method which unnecessarily requests `ACCESS_FINE_LOCATION` even though `NEARBY_WIFI_DEVICES` (which is a more privacy-friendly) would be enough (at least starting from Android 13, see https://developer.android.com/develop/connectivity/wifi/wifi-permissions).

I asked Claude Code to perform the desired changes (since Kotlin is not my primary language) and this is what it came up with. I tested the updated library on physical devices (Android 12 and 16) to make sure the edits work as expected. Would be great if you could take a look as well and kindly let me know, if I missed anything.

Here's a screenshot of the new `NEARBY_WIFI_DEVICES` permission prompt:

![Screenshot_20251203_120629_Permission controller](https://github.com/user-attachments/assets/bd642175-9c15-4bdd-bec3-e20326a30bcf)

Thanks for keeping this library up to date! :)